### PR TITLE
Changed default guard back to web

### DIFF
--- a/config/bastion.php
+++ b/config/bastion.php
@@ -13,7 +13,7 @@ return [
 
     ],
 
-    'default_guard' => 'sanctum',
+    'default_guard' => 'web',
     'guards' => [
         // value => 'Custom Label'
         'web' => 'Web',


### PR DESCRIPTION
Sanctum gets added on the fly and should not be the guard set on a Role.