### PR TITLE
feat: add SSO role prefix configuration

### DIFF
--- a/config/bastion.php
+++ b/config/bastion.php
@@ -23,5 +23,6 @@ return [
 
     'sso' => [
         'enabled' => false,
+        'role_prefix' => env('SSO_ROLE_PREFIX', 'SSO-'),
     ],
 ];


### PR DESCRIPTION
Added environment-based SSO role prefix setting to allow dynamic prefixing for single sign-on roles, enhancing integration flexibility.