### PR TITLE
🔧 chore: Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1]
-        laravel: [10.*]
+        os: [ubuntu-latest]
+        php: [8.3, 8.2]
+        laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
+            carbon: ^2.63
+          - laravel: 11.*
+            testbench: 9.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,11 +18,14 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
-            testbench: ^8.14
+            testbench: 8.*
             carbon: ^2.63
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^2.63
+            carbon: ^3.0
+        exclude:
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
-            testbench: 8.*
+            testbench: ^8.14
             carbon: ^2.63
           - laravel: 11.*
             testbench: 9.*

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
     },
     "require-dev": {
         "laravel/pint": "^1.13",
-        "nunomaduro/collision": "^7.10|^8.0",
+        "nunomaduro/collision": "^7.9|^8.0",
         "nunomaduro/larastan": "^2.1.1",
-        "orchestra/testbench": "^8.14|^9.0",
-        "pestphp/pest": "^2.10",
+        "orchestra/testbench": "^8.0|^9.0",
+        "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "php": "^8.1",
         "chrisreedio/filament-policy-generator": "^3.0.0",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10|^11",
         "spatie/laravel-package-tools": "^1.15.0",
         "spatie/laravel-permission": "^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
     },
     "require-dev": {
         "laravel/pint": "^1.13",
-        "nunomaduro/collision": "^7.9|^8.0",
+        "nunomaduro/collision": "^7.10|^8.0",
         "nunomaduro/larastan": "^2.1.1",
-        "orchestra/testbench": "^8.0|^9.0",
+        "orchestra/testbench": "^v8.22|^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.1",
         "chrisreedio/filament-policy-generator": "^3.0.0",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/contracts": "^10|^11",
         "spatie/laravel-package-tools": "^1.15.0",
         "spatie/laravel-permission": "^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.3"
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpunit/phpunit": "^10.4.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,15 @@
         "php": "^8.1",
         "chrisreedio/filament-policy-generator": "^3.0.0",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0",
+        "illuminate/contracts": "^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.15.0",
         "spatie/laravel-permission": "^6.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13",
-        "nunomaduro/collision": "^7.10",
+        "nunomaduro/collision": "^7.10|^8.0",
         "nunomaduro/larastan": "^2.1.1",
-        "orchestra/testbench": "^8.11",
+        "orchestra/testbench": "^8.14|^9.0",
         "pestphp/pest": "^2.10",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",


### PR DESCRIPTION
Updated `illuminate/contracts`, `nunomaduro/collision`, and `orchestra/testbench` to support newer versions.