### PR TITLE
Filament v4 Parent Resource Check Compatibility

### DIFF
--- a/src/Bastion.php
+++ b/src/Bastion.php
@@ -40,7 +40,7 @@ class Bastion
         // Check for the existence of a getParentResource method on the resource
         // TODO: If it exists, we need to get the parent resource and sync it first
         // For now, we're just going to skip it to let that parent resource sync itself
-        if (method_exists($resource, 'getParentResource')) {
+        if (method_exists($resource, 'getParentResource') && $resource::getParentResource() !== null) {
             return false;
         }
 


### PR DESCRIPTION
We had chosen to use this method name before Filament v4. Now, with the introduction of nested resources in Filament v4, to enhance this check. 